### PR TITLE
Problem: selftests used fixed port numbers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,8 +157,8 @@ pipeline {
                 }
             }
         }
-//        stage ('check') {
-//            parallel {
+        stage ('check') {
+            parallel {
                 stage ('check with DRAFT') {
                     when { expression { return ( params.DO_BUILD_WITH_DRAFT_API && params.DO_TEST_CHECK ) } }
                     steps {
@@ -324,8 +324,8 @@ pipeline {
                       }
                     }
                 }
-//            }
-//        }
+            }
+        }
         stage ('deploy if appropriate') {
             steps {
                 script {

--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -873,6 +873,25 @@ mlm_services_api_test (bool verbose)
     printf ("OK\n");
 }
 
+static void
+s_get_server_port (zactor_t *server, char *endpoint)
+{
+    char *command, *port;
+
+    int rc = zstr_sendx (server, "PORT", NULL);
+    assert (rc == 0);
+
+    rc = zstr_recvx (server, &command, &port, NULL);
+    assert (rc == 2);
+    assert (strlen (command) == 4);
+    assert (streq (command, "PORT"));
+    assert (strlen (port) > 0 && strlen (port) < 6);
+    assert (!streq (port, "-1"));
+    sprintf (endpoint, "tcp://127.0.0.1:%s", port);
+
+    zstr_free (&command);
+    zstr_free (&port);
+}
 
 void
 mlm_client_test (bool verbose)
@@ -911,6 +930,9 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+
+    char endpoint [255];
+    s_get_server_port (server, endpoint);
 
     //  Install authenticator to test PLAIN access
     zactor_t *auth = zactor_new (zauth, NULL);
@@ -957,6 +979,7 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+    s_get_server_port (server, endpoint);
 
     client = mlm_client_new ();
     assert (client);
@@ -977,6 +1000,7 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+    s_get_server_port (server, endpoint);
     rc = mlm_client_set_producer (client, "new_stream");
     assert ( rc == -1 ); // the  method set producer is called too fast,
     // so, the client didn't manage to establish a new connection with
@@ -1003,6 +1027,7 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+    s_get_server_port (server, endpoint);
 
     client = mlm_client_new ();
     assert (client);
@@ -1025,6 +1050,7 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+    s_get_server_port (server, endpoint);
     zclock_sleep (5000); // wait a bit
     // after a while we are connected again
     assert (mlm_client_connected (client) == true);
@@ -1046,6 +1072,7 @@ mlm_client_test (bool verbose)
     }
     rc = zstr_sendx (server, "LOAD", "src/mlm_client.cfg", NULL);
     assert (rc == 0);
+    s_get_server_port (server, endpoint);
 
     //  Test stream pattern
     mlm_client_t *writer = mlm_client_new ();

--- a/src/mlm_client.cfg
+++ b/src/mlm_client.cfg
@@ -15,4 +15,4 @@ mlm_server
     security
         mechanism = plain
     bind
-        endpoint = tcp://127.0.0.1:9999
+        endpoint = tcp://127.0.0.1:*

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -688,11 +688,18 @@ mlm_server_test (bool verbose)
     zactor_t *server = zactor_new (mlm_server, "mlm_server_test");
     if (verbose)
         zstr_send (server, "VERBOSE");
-    zstr_sendx (server, "BIND", "tcp://127.0.0.1:9999", NULL);
+    zstr_sendx (server, "BIND", "tcp://127.0.0.1:*", NULL);
+    zstr_sendx (server, "PORT", NULL);
+    char *command, *port;
+    int rc = zstr_recvx (server, &command, &port, NULL);
+    assert (rc == 2);
+    assert (streq (command, "PORT"));
+    assert (strlen (port) > 0 && strlen (port) < 6);
+    assert (!streq (port, "-1"));
 
     zsock_t *reader = zsock_new (ZMQ_DEALER);
     assert (reader);
-    zsock_connect (reader, "tcp://127.0.0.1:9999");
+    zsock_connect (reader, "tcp://127.0.0.1:%s", port);
     zsock_set_rcvtimeo (reader, 500);
 
     mlm_proto_t *proto = mlm_proto_new ();
@@ -707,7 +714,7 @@ mlm_server_test (bool verbose)
     //  Now do a stream publish-subscribe test
     zsock_t *writer = zsock_new (ZMQ_DEALER);
     assert (writer);
-    zsock_connect (writer, "tcp://127.0.0.1:9999");
+    zsock_connect (writer, "tcp://127.0.0.1:%s", port);
     zsock_set_rcvtimeo (reader, 500);
 
     //  Open connections from both reader and writer
@@ -768,6 +775,8 @@ mlm_server_test (bool verbose)
     zsock_destroy (&writer);
     zsock_destroy (&reader);
     zactor_destroy (&server);
+    zstr_free (&port);
+    zstr_free (&command);
 
     //  @end
     printf ("OK\n");

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -1386,7 +1386,8 @@ s_server_config_service (s_server_t *self)
         else
         if (streq (zconfig_name (section), "bind")) {
             char *endpoint = zconfig_resolve (section, "endpoint", "?");
-            if (zsock_bind (self->router, "%s", endpoint) == -1)
+            self->port = zsock_bind (self->router, "%s", endpoint);
+            if (self->port == -1)
                 zsys_warning ("could not bind to %s (%s)", endpoint, zmq_strerror (zmq_errno ()));
         }
 #if (ZMQ_VERSION_MAJOR >= 4)


### PR DESCRIPTION
Solution: port solution of https://github.com/zeromq/malamute/pull/295 to our old codebase and unblock parallel testing in Jenkins. See what happens.