### PR TITLE
 [issues/217] mlm_client_set_consumer broke the stream when pattern is *

### DIFF
--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1723,8 +1723,11 @@ int
 mlm_client_set_consumer (mlm_client_t *self, const char *stream, const char *pattern)
 {
     assert (self);
-
-    zsock_send (self->actor, "sss", "SET CONSUMER", stream, pattern);
+    // https://github.com/zeromq/malamute/issues/217
+    // problem  : if pattern "*" is used, the related stream is broken and mlm broker starting overcosumming 100% CPU forever
+    // solution : replace "*" by ".*" to avoid the issue
+    const char *_pattern = (streq(pattern,"*")?".*": pattern);
+    zsock_send (self->actor, "sss", "SET CONSUMER", stream, _pattern);
     if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
         return -1;              //  Interrupted or timed-out
     return self->status;

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1726,8 +1726,8 @@ mlm_client_set_consumer (mlm_client_t *self, const char *stream, const char *pat
     // https://github.com/zeromq/malamute/issues/217
     // problem  : if pattern "*" is used, the related stream will be broken and
     //            mlm broker will start overcosumming 100% CPU forever
-    // solution : replace "*" by ".*" to avoid the issue
-    const char *_pattern = (streq(pattern,"*")?".*": pattern);
+    if (streq(pattern,"*"))
+        return -1;
     zsock_send (self->actor, "sss", "SET CONSUMER", stream, _pattern);
     if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
         return -1;              //  Interrupted or timed-out

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1728,7 +1728,7 @@ mlm_client_set_consumer (mlm_client_t *self, const char *stream, const char *pat
     //            mlm broker will start overcosumming 100% CPU forever
     if (streq(pattern,"*"))
         return -1;
-    zsock_send (self->actor, "sss", "SET CONSUMER", stream, _pattern);
+    zsock_send (self->actor, "sss", "SET CONSUMER", stream, pattern);
     if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
         return -1;              //  Interrupted or timed-out
     return self->status;

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1724,7 +1724,8 @@ mlm_client_set_consumer (mlm_client_t *self, const char *stream, const char *pat
 {
     assert (self);
     // https://github.com/zeromq/malamute/issues/217
-    // problem  : if pattern "*" is used, the related stream is broken and mlm broker starting overcosumming 100% CPU forever
+    // problem  : if pattern "*" is used, the related stream will be broken and
+    //            mlm broker will start overcosumming 100% CPU forever
     // solution : replace "*" by ".*" to avoid the issue
     const char *_pattern = (streq(pattern,"*")?".*": pattern);
     zsock_send (self->actor, "sss", "SET CONSUMER", stream, _pattern);


### PR DESCRIPTION
Problem : https://github.com/zeromq/malamute/issues/217
if pattern "*" is used, the related stream will be broken and mlm broker will start overcosumming 100% CPU forever

solution : if pattern is * mlm_set_consumer reject it

Note : as mlm_client_engine.inc is auto generated by gsl (https://github.com/zeromq/zproto/blob/master/src/zproto_client_c.gsl), it's quite really complex to handle this issue in a clean way. This is why we took a different approach, so this patch is not pushed on upstream.

Signed-off-by: Gerald Guillaume geraldguillaume@eaton.com