### PR TITLE
Problem: "snprintf_chk output truncated before the last format character"

### DIFF
--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -210,7 +210,7 @@ s_client_new (zsock_t *cmdpipe, zsock_t *msgpipe)
         self->msgpipe = msgpipe;
         self->state = start_state;
         self->event = NULL_event;
-        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+        snprintf (self->log_prefix, sizeof (self->log_prefix),
             "%6d:%-33s", randof (1000000), "mlm_client");
         self->dealer = zsock_new (ZMQ_DEALER);
         if (self->dealer)

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -337,7 +337,7 @@ engine_set_log_prefix (client_t *client, const char *string)
 {
     if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
-        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+        snprintf (self->log_prefix, sizeof (self->log_prefix),
             "%6d:%-33s", self->unique_id, string);
     }
 }


### PR DESCRIPTION
Solution: snprintf() already truncates to "bufsize-1" (and adds `\0`) if needed, per docs, so we do not need to reduce it more.

This change matches current upstream malamute sources.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>